### PR TITLE
Fix issue with tags being added when cloning fieldpane.

### DIFF
--- a/islandora_form_fieldpanel.module
+++ b/islandora_form_fieldpanel.module
@@ -122,9 +122,37 @@ function islandora_form_fieldpanel_form_element_fieldpanel_ajax_alter(FormElemen
 function islandora_form_fieldpanel_form_element_fieldpane_ajax_add(FormElement $element, array &$form, array &$form_state) {
   $pane = $element->findElement($form_state['triggering_element']['#ajax']['params']['child']);
   $new_pane = clone $pane;
-  $new_pane->eachDecendant(function($element) {
-    $element->default_value = NULL;
-  });
+
+  $each_function = function ($element) {
+    // Set a FormElement to its default value.
+    $set_to_default = function ($el) {
+      $el->default_value = $el->getOriginalDefaultValue();
+    };
+
+    // Set this one...
+    $set_to_default($element);
+
+    if ($element->controls['#type'] == 'tags') {
+      // ... and make child "tag" elements unique.
+      // First, map 'em all to their defaults.
+      array_map($set_to_default, $element->children);
+
+      // Filter function: Only pass unique values.
+      $child_filter = function ($child) {
+        static $values = array();
+        $value = $child->default_value;
+        if (!in_array($value, $values)) {
+          $values[] = $value;
+          return TRUE;
+        }
+        return FALSE;
+      };
+      // Run the filter function.
+      $element->children = array_filter($element->children, $child_filter);
+    }
+  };
+  $new_pane->eachDecendant($each_function);
+
   $element->adopt($new_pane);
   $form[] = $new_pane->toArray();
 }


### PR DESCRIPTION
**JIRA Ticket**: [ISLANDORA-2315](https://jira.duraspace.org/browse/ISLANDORA-2315)

# What does this Pull Request do?

Fixes an issue with blank tags (along with "remove-tag" buttons when using islandora_xml_forms) being added to cloned fieldpanes if tags have been added to the initial pane.

# What's new?
When cloning, sets child "tag" elements to their default value, then properly filters out duplicate elements so we don't end up with multiple empty tags being added to the cloned pane.

# How should this be tested?
Steps to reproduce:
* Enable islandora_xml_forms module
* Create a form with tag field inside a fieldpanel/fieldpane
* Add at least 1 tag to the field
* Click button to add a new fieldpane
* Verify that no (-) buttons are present below the tag field of new fieldpane (indicating no tags have been carried over)

# Additional Notes:
Code basically lifted from the [tabpanel cloning code](https://github.com/Islandora/islandora_xml_forms/blob/7.x/elements/xml_form_elements.module#L374)

# Interested parties
@whikloj 
